### PR TITLE
replacing uefi="yes" by loader="uefi"

### DIFF
--- a/src/ixautomation/vms/.templates/freenas.conf
+++ b/src/ixautomation/vms/.templates/freenas.conf
@@ -1,4 +1,4 @@
-uefi="yes"
+loader="uefi"
 cpu=1
 memory=8G
 network0_type="virtio-net"


### PR DESCRIPTION
uefi="yes" is deprecated in the new vm-bhyve