### PR TITLE
bump scale vm cpu to 8

### DIFF
--- a/src/ixautomation/vms/.templates/scale-api.conf
+++ b/src/ixautomation/vms/.templates/scale-api.conf
@@ -1,5 +1,5 @@
 loader="uefi"
-cpu=2
+cpu=8
 memory=8G
 network0_type="virtio-net"
 network0_switch="ixautomation"


### PR DESCRIPTION
2 cpu cores doesn't meet the recommended minimum requirements for our product. We're seeing 4+ hours to run our test suite but we're also seeing standard API calls timeout because there is not enough CPU. Bump this to 8 to meet the minimum required specs.